### PR TITLE
simplify params + other little fixes

### DIFF
--- a/leveled_up_demo_workflow/workflow/Snakefile
+++ b/leveled_up_demo_workflow/workflow/Snakefile
@@ -19,7 +19,7 @@ rule fastqc:
         html = temp(["../results/fastqc/{sample}_1_fastqc.html", "../results/fastqc/{sample}_2_fastqc.html"]),
         zip = ["../results/fastqc/{sample}_1_fastqc.zip", "../results/fastqc/{sample}_2_fastqc.zip"]
     params:
-        fastqc_params = expand("{fastqc_params}", fastqc_params = config['PARAMS']['FASTQC'])
+        fastqc_params = config['PARAMS']['FASTQC']
     log:
         "logs/fastqc/{sample}.log"
     threads: 2
@@ -36,7 +36,7 @@ rule multiqc:
     output:
         "../results/multiqc_report.html"
     params:
-        multiqc_params = expand("{multiqc_params}", multiqc_params = config['PARAMS']['MULTIQC'])
+        multiqc_params = config['PARAMS']['MULTIQC']
     log:
         "logs/multiqc/multiqc.log"
     conda:
@@ -57,8 +57,8 @@ rule trim_galore:
         "logs/trim_galore/{sample}.log"
     conda:
         "./envs/trim_galore.yaml"
-    threads: 8
+    threads: 2
     message:
-      "Trimming using these parameter: {params}. Writing logs to {log}. Using {threads} threads."
+        "Trimming using these parameter: {params}. Writing logs to {log}. Using {threads} threads."
     shell:
         "trim_galore {input} -o ../results/trimmed/ {params} --cores {threads} &> {log}"

--- a/leveled_up_demo_workflow/workflow/slurm/config.yaml
+++ b/leveled_up_demo_workflow/workflow/slurm/config.yaml
@@ -1,3 +1,3 @@
 jobs: 20
-cluster: "sbatch --time {resources.time_min} --mem={resources.mem_mb} --cpus-per-task {resources.cpus}"
+cluster: "sbatch --time {resources.time_min} --mem={resources.mem_mb} --cpus-per-task {resources.cpus} --account nesi99991"
 default-resources: [cpus=2, mem_mb=512, time_min=10]

--- a/workshop_material/03_create_a_basic_workflow.md
+++ b/workshop_material/03_create_a_basic_workflow.md
@@ -1412,7 +1412,7 @@ In addition, you need to specify a maximum number of concurrent jobs using `--jo
 rm -r ../results/*
 
 # run again on the cluster
-snakemake --cluster "sbatch --time 00:10:00 --mem=512MB --cpus-per-task 8" --jobs 10 --use-conda
+snakemake --cluster "sbatch --time 00:10:00 --mem=512MB --cpus-per-task 8 --account nesi99991" --jobs 10 --use-conda
 ```
 
 If you open another terminal on the HPC, you can use the `squeue` command to list of your jobs and their state (pending, running, etc.):

--- a/workshop_material/04_leveling_up_your_workflow.md
+++ b/workshop_material/04_leveling_up_your_workflow.md
@@ -703,7 +703,7 @@ snakemake --dryrun --profile slurm --use-conda
 snakemake --profile slurm --use-conda
 ```
 
-Now when we have a look at the `results/trimmed/` directory with:
+Now when we have a look at the `../results/fastqc/` directory with:
 
 ```bash
 ls -lh ../results/fastqc/

--- a/workshop_material/04_leveling_up_your_workflow.md
+++ b/workshop_material/04_leveling_up_your_workflow.md
@@ -209,7 +209,7 @@ SAMPLES, = glob_wildcards("../../data/{sample}_1.fastq.gz")
 rule all:
     input:
         "../results/multiqc_report.html",
-        expand("../results/mapped/{sample}.bam", sample = SAMPLES)
+        expand(["../results/trimmed/{sample}_1_val_1.fq.gz", "../results/trimmed/{sample}_2_val_2.fq.gz"], sample = SAMPLES)
 
 # workflow
 rule fastqc:
@@ -315,7 +315,7 @@ SAMPLES, = glob_wildcards("../../data/{sample}_1.fastq.gz")
 rule all:
     input:
         "../results/multiqc_report.html",
-        expand("../results/mapped/{sample}.bam", sample = SAMPLES)
+        expand(["../results/trimmed/{sample}_1_val_1.fq.gz", "../results/trimmed/{sample}_2_val_2.fq.gz"], sample = SAMPLES)
 
 # workflow
 rule fastqc:

--- a/workshop_material/04_leveling_up_your_workflow.md
+++ b/workshop_material/04_leveling_up_your_workflow.md
@@ -326,7 +326,7 @@ rule fastqc:
         html = ["../results/fastqc/{sample}_1_fastqc.html", "../results/fastqc/{sample}_2_fastqc.html"],
         zip = ["../results/fastqc/{sample}_1_fastqc.zip", "../results/fastqc/{sample}_2_fastqc.zip"]
 +   params:
-+       fastqc_params = expand("{fastqc_params}", fastqc_params = config['PARAMS']['FASTQC'])
++       fastqc_params = config['PARAMS']['FASTQC']
     log:
         "logs/fastqc/{sample}.log"
     threads: 2
@@ -342,7 +342,7 @@ rule multiqc:
     output:
         "../results/multiqc_report.html"
 +   params:
-+       multiqc_params = expand("{multiqc_params}", multiqc_params = config['PARAMS']['MULTIQC'])
++       multiqc_params = config['PARAMS']['MULTIQC']
     log:
         "logs/multiqc/multiqc.log"
     conda:
@@ -425,7 +425,7 @@ rule fastqc:
         html = ["../results/fastqc/{sample}_1_fastqc.html", "../results/fastqc/{sample}_2_fastqc.html"],
         zip = ["../results/fastqc/{sample}_1_fastqc.zip", "../results/fastqc/{sample}_2_fastqc.zip"]
     params:
-        fastqc_params = expand("{fastqc_params}", fastqc_params = config['PARAMS']['FASTQC'])
+        fastqc_params = config['PARAMS']['FASTQC']
     log:
         "logs/fastqc/{sample}.log"
     threads: 2
@@ -440,7 +440,7 @@ rule multiqc:
     output:
         "../results/multiqc_report.html"
     params:
-        multiqc_params = expand("{multiqc_params}", multiqc_params = config['PARAMS']['MULTIQC'])
+        multiqc_params = config['PARAMS']['MULTIQC']
     log:
         "logs/multiqc/multiqc.log"
     conda:
@@ -509,7 +509,7 @@ rule fastqc:
         html = ["../results/fastqc/{sample}_1_fastqc.html", "../results/fastqc/{sample}_2_fastqc.html"],
         zip = ["../results/fastqc/{sample}_1_fastqc.zip", "../results/fastqc/{sample}_2_fastqc.zip"]
     params:
-        fastqc_params = expand("{fastqc_params}", fastqc_params = config['PARAMS']['FASTQC'])
+        fastqc_params = config['PARAMS']['FASTQC']
     log:
         "logs/fastqc/{sample}.log"
     threads: 2
@@ -526,7 +526,7 @@ rule multiqc:
     output:
         "../results/multiqc_report.html"
     params:
-        multiqc_params = expand("{multiqc_params}", multiqc_params = config['PARAMS']['MULTIQC'])
+        multiqc_params = config['PARAMS']['MULTIQC']
     log:
         "logs/multiqc/multiqc.log"
     conda:
@@ -649,7 +649,7 @@ rule fastqc:
 +       html = temp(["../results/fastqc/{sample}_1_fastqc.html", "../results/fastqc/{sample}_2_fastqc.html"]),
         zip = ["../results/fastqc/{sample}_1_fastqc.zip", "../results/fastqc/{sample}_2_fastqc.zip"]
     params:
-        fastqc_params = expand("{fastqc_params}", fastqc_params = config['PARAMS']['FASTQC'])
+        fastqc_params = config['PARAMS']['FASTQC']
     log:
         "logs/fastqc/{sample}.log"
     threads: 2
@@ -666,7 +666,7 @@ rule multiqc:
     output:
         "../results/multiqc_report.html"
     params:
-        multiqc_params = expand("{multiqc_params}", multiqc_params = config['PARAMS']['MULTIQC'])
+        multiqc_params = config['PARAMS']['MULTIQC']
     log:
         "logs/multiqc/multiqc.log"
     conda:

--- a/workshop_material/04_leveling_up_your_workflow.md
+++ b/workshop_material/04_leveling_up_your_workflow.md
@@ -265,7 +265,7 @@ Run a dryrun to check it works
 rm -r ../results/*
 
 # run dryrun again
-snakemake --dryrun --profile slurm --use-conda
+snakemake --dryrun --cores 2 --use-conda
 ```
 
 ## 4.3 Pull out user configurable options
@@ -376,8 +376,8 @@ Let's use our configuration file! Run workflow again:
 rm -r ../results/*
 
 # run dryrun/run again
-snakemake --dryrun --profile slurm --use-conda
-snakemake --profile slurm --use-conda
+snakemake --dryrun --cores 2 --use-conda
+snakemake --cores 2 --use-conda
 ```
 
 Didn't work? Error:
@@ -395,10 +395,10 @@ Snakemake can't find our 'Key' - we haven't told Snakemake where our config file
 rm -r ../results/*
 
 # run dryrun/run again
-- snakemake --dryrun --profile slurm --use-conda
-- snakemake --profile slurm --use-conda
-+ snakemake --dryrun --profile slurm --use-conda --configfile ../config/config.yaml
-+ snakemake --profile slurm --use-conda --configfile ../config/config.yaml
+- snakemake --dryrun --cores 2 --use-conda
+- snakemake --cores 2 --use-conda
++ snakemake --dryrun --cores 2 --use-conda --configfile ../config/config.yaml
++ snakemake --cores 2 --use-conda --configfile ../config/config.yaml
 ```
 
 Alternatively, we can define our config file in our Snakefile in a situation where the configuration file is likely to always be named the same and be in the exact same location `../config/config.yaml` and you don't need the flexibility for the user to specify their own configuration files:
@@ -473,10 +473,10 @@ Then we don't need to specify where the configuration file is on the command lin
 rm -r ../results/*
 
 # run dryrun/run again
-- snakemake --dryrun --profile slurm --use-conda --configfile ../config/config.yaml
-- snakemake --profile slurm --use-conda --configfile ../config/config.yaml
-+ snakemake --dryrun --profile slurm --use-conda
-+ snakemake --profile slurm --use-conda
++ snakemake --dryrun --cores 2 --use-conda
++ snakemake --cores 2 --use-conda
+- snakemake --dryrun --cores 2 --use-conda --configfile ../config/config.yaml
+- snakemake --cores 2 --use-conda --configfile ../config/config.yaml
 ```
 
 ## 4.4 Leave messages for the user
@@ -561,8 +561,8 @@ rule trim_galore:
 rm -r ../results/*
 
 # run dryrun/run again
-snakemake --dryrun --profile slurm --use-conda
-snakemake --profile slurm --use-conda
+snakemake --dryrun --cores 2 --use-conda
+snakemake --cores 2 --use-conda
 ```
 
 Now our messages are printed to the screen as our workflow runs
@@ -699,8 +699,8 @@ rule trim_galore:
 rm -r ../results/*
 
 # run dryrun/run again
-snakemake --dryrun --profile slurm --use-conda
-snakemake --profile slurm --use-conda
+snakemake --dryrun --cores 2 --use-conda
+snakemake --cores 2 --use-conda
 ```
 
 Now when we have a look at the `../results/fastqc/` directory with:

--- a/workshop_material/04_leveling_up_your_workflow.md
+++ b/workshop_material/04_leveling_up_your_workflow.md
@@ -265,7 +265,7 @@ Run a dryrun to check it works
 rm -r ../results/*
 
 # run dryrun again
-snakemake --dryrun --cores 2 --use-conda
+snakemake --dryrun --profile slurm --use-conda
 ```
 
 ## 4.3 Pull out user configurable options
@@ -376,8 +376,8 @@ Let's use our configuration file! Run workflow again:
 rm -r ../results/*
 
 # run dryrun/run again
-snakemake --dryrun --cores 2 --use-conda
-snakemake --cores 2 --use-conda
+snakemake --dryrun --profile slurm --use-conda
+snakemake --profile slurm --use-conda
 ```
 
 Didn't work? Error:
@@ -395,10 +395,10 @@ Snakemake can't find our 'Key' - we haven't told Snakemake where our config file
 rm -r ../results/*
 
 # run dryrun/run again
-- snakemake --dryrun --cores 2 --use-conda
-- snakemake --cores 2 --use-conda
-+ snakemake --dryrun --cores 2 --use-conda --configfile ../config/config.yaml
-+ snakemake --cores 2 --use-conda --configfile ../config/config.yaml
+- snakemake --dryrun --profile slurm --use-conda
+- snakemake --profile slurm --use-conda
++ snakemake --dryrun --profile slurm --use-conda --configfile ../config/config.yaml
++ snakemake --profile slurm --use-conda --configfile ../config/config.yaml
 ```
 
 Alternatively, we can define our config file in our Snakefile in a situation where the configuration file is likely to always be named the same and be in the exact same location `../config/config.yaml` and you don't need the flexibility for the user to specify their own configuration files:
@@ -473,10 +473,10 @@ Then we don't need to specify where the configuration file is on the command lin
 rm -r ../results/*
 
 # run dryrun/run again
-+ snakemake --dryrun --cores 2 --use-conda
-+ snakemake --cores 2 --use-conda
-- snakemake --dryrun --cores 2 --use-conda --configfile ../config/config.yaml
-- snakemake --cores 2 --use-conda --configfile ../config/config.yaml
+- snakemake --dryrun --profile slurm --use-conda --configfile ../config/config.yaml
+- snakemake --profile slurm --use-conda --configfile ../config/config.yaml
++ snakemake --dryrun --profile slurm --use-conda
++ snakemake --profile slurm --use-conda
 ```
 
 ## 4.4 Leave messages for the user
@@ -561,8 +561,8 @@ rule trim_galore:
 rm -r ../results/*
 
 # run dryrun/run again
-snakemake --dryrun --cores 2 --use-conda
-snakemake --cores 2 --use-conda
+snakemake --dryrun --profile slurm --use-conda
+snakemake --profile slurm --use-conda
 ```
 
 Now our messages are printed to the screen as our workflow runs
@@ -699,8 +699,8 @@ rule trim_galore:
 rm -r ../results/*
 
 # run dryrun/run again
-snakemake --dryrun --cores 2 --use-conda
-snakemake --cores 2 --use-conda
+snakemake --dryrun --profile slurm --use-conda
+snakemake --profile slurm --use-conda
 ```
 
 Now when we have a look at the `results/trimmed/` directory with:

--- a/workshop_material/04_leveling_up_your_workflow.md
+++ b/workshop_material/04_leveling_up_your_workflow.md
@@ -89,7 +89,7 @@ touch slurm/config.yaml
 
 # write the following to config.yaml
 jobs: 20
-cluster: "sbatch --time 00:10:00 --mem=512MB --cpus-per-task 8"
+cluster: "sbatch --time 00:10:00 --mem=512MB --cpus-per-task 8 --account nesi99991"
 ```
 
 Then run the snakemake workflow using the `slurm` profile
@@ -111,7 +111,7 @@ Update the profile `slurm/config.yaml` file as follows
 ```diff
 jobs: 20
 - cluster: "sbatch --time 00:10:00 --mem=512MB --cpus-per-task 8"
-+ cluster: "sbatch --time {resources.time_min} --mem={resources.mem_mb} --cpus-per-task {resources.cpus}"
++ cluster: "sbatch --time {resources.time_min} --mem={resources.mem_mb} --cpus-per-task {resources.cpus} --account nesi99991"
 + default-resources: [cpus=2, mem_mb=512, time_min=10]
 ```
 


### PR DESCRIPTION
- add slurm account when submitting to slurm to avoid error
- simplify params directive (eg. `fastqc_params = config['PARAMS']['FASTQC']` instead of `fastqc_params = expand("{fastqc_params}", fastqc_params = config['PARAMS']['FASTQC'])`
- fix old rule all target that wasn't updated (was pointing to an old bam target file)
- continue deploying to slurm after section 4.1
- fix typo