### PR TITLE
Last last pass

### DIFF
--- a/workshop_material/03_create_a_basic_workflow.md
+++ b/workshop_material/03_create_a_basic_workflow.md
@@ -259,7 +259,8 @@ rule all:
 +       "../results/fastqc/NA24631_2_fastqc.zip"
 
 # workflow
-rule fastqc:
+- rule my_rule:
++ rule fastqc:
     input:
 +       R1 = "../../data/NA24631_1.fastq.gz",
 +       R2 = "../../data/NA24631_2.fastq.gz"

--- a/workshop_material/03_create_a_basic_workflow.md
+++ b/workshop_material/03_create_a_basic_workflow.md
@@ -2016,10 +2016,8 @@ Complete log: .snakemake/log/2022-05-11T122639.019945.snakemake.log
 If you open another terminal on the HPC, you can use the `squeue` command to list of your jobs and their state (pending, running, etc.):
 
 ```bash
-squeue -u your_nesi_login
+squeue --me
 ```
-
-where `your_nesi_login` needs to be replace with your actual NeSI login.
 
 My output:
 
@@ -2045,7 +2043,7 @@ An additional trick is to use the `watch` command to repeatedly call any command
 Here we will use it to see your jobs gets queued and executed in real time:
 
 ```bash
-watch squeue -u your_nesi_login
+watch squeue --me
 ```
 
 You can exit the view create by `watch` by pressing CTRL+C.

--- a/workshop_material/04_leveling_up_your_workflow.md
+++ b/workshop_material/04_leveling_up_your_workflow.md
@@ -620,8 +620,10 @@ File structure:
 demo_workflow/
       |_______results/
       |_______workflow/
-      |          |_______envs/
+      |          |_______logs/
+      |          |_______slurm/
       |          |_______Snakefile
+      |          |_______status.py
       |_______config
                  |_______config.yaml
 ```

--- a/workshop_material/04_leveling_up_your_workflow.md
+++ b/workshop_material/04_leveling_up_your_workflow.md
@@ -609,7 +609,7 @@ Run a dryrun to check it works
 rm -r ../results/*
 
 # run dryrun again
-snakemake --dryrun --profile slurm --cores 2 --use-envmodules
+snakemake --dryrun --profile slurm --use-envmodules
 ```
 
 ## 4.3 Pull out user configurable options
@@ -791,8 +791,8 @@ Let's use our configuration file! Run workflow again:
 rm -r ../results/*
 
 # run dryrun/run again
-snakemake --dryrun --profile slurm --cores 2 --use-envmodules
-snakemake --profile slurm --cores 2 --use-envmodules
+snakemake --dryrun --profile slurm --use-envmodules
+snakemake --profile slurm --use-envmodules
 ```
 
 Didn't work?
@@ -819,10 +819,10 @@ Snakemake can't find our 'Key' - we haven't told Snakemake where our config file
 rm -r ../results/
 
 # run dryrun/run again
-- snakemake --dryrun --profile slurm --cores 2 --use-envmodules
-- snakemake --profile slurm --cores 2 --use-envmodules
-+ snakemake --dryrun --profile slurm --cores 2 --use-envmodules --configfile ../config/config.yaml
-+ snakemake --profile slurm --cores 2 --use-envmodules --configfile ../config/config.yaml
+- snakemake --dryrun --profile slurm --use-envmodules
+- snakemake --profile slurm --use-envmodules
++ snakemake --dryrun --profile slurm --use-envmodules --configfile ../config/config.yaml
++ snakemake --profile slurm --use-envmodules --configfile ../config/config.yaml
 ```
 
 Alternatively, we can define our config file in our Snakefile in a situation where the configuration file is likely to always be named the same and be in the exact same location `../config/config.yaml` and you don't need the flexibility for the user to specify their own configuration files:
@@ -969,10 +969,10 @@ Then we don't need to specify where the configuration file is on the command lin
 rm -r ../results/*
 
 # run dryrun/run again
-- snakemake --dryrun --profile slurm --cores 2 --use-envmodules --configfile ../config/config.yaml
-- snakemake --profile slurm --cores 2 --use-envmodules --configfile ../config/config.yaml
-+ snakemake --dryrun --profile slurm --cores 2 --use-envmodules
-+ snakemake --profile slurm --cores 2 --use-envmodules
+- snakemake --dryrun --profile slurm --use-envmodules --configfile ../config/config.yaml
+- snakemake --profile slurm --use-envmodules --configfile ../config/config.yaml
++ snakemake --dryrun --profile slurm --use-envmodules
++ snakemake --profile slurm --use-envmodules
 ```
 
 ## 4.4 Leave messages for the user
@@ -1135,8 +1135,8 @@ rule trim_galore:
 rm -r ../results/*
 
 # run dryrun/run again
-snakemake --dryrun --profile slurm --cores 2 --use-envmodules
-snakemake --profile slurm --cores 2 --use-envmodules
+snakemake --dryrun --profile slurm --use-envmodules
+snakemake --profile slurm --use-envmodules
 ```
 
 Now our messages are printed to the screen as our workflow runs
@@ -1425,8 +1425,8 @@ rule trim_galore:
 rm -r ../results/*
 
 # run dryrun/run again
-snakemake --dryrun --profile slurm --cores 2 --use-envmodules
-snakemake --profile slurm --cores 2 --use-envmodules
+snakemake --dryrun --profile slurm --use-envmodules
+snakemake --profile slurm --use-envmodules
 ```
 
 Now when we have a look at the `../results/fastqc/` directory with:

--- a/workshop_material/04_leveling_up_your_workflow.md
+++ b/workshop_material/04_leveling_up_your_workflow.md
@@ -395,7 +395,17 @@ Note that `logs/slurm/slurm-%j-{rule}.out` contains a placeholder `{rule}`, whic
 Finally, to improve the communication between Snakemake and Slurm, we meed an additional script translating Slurm job status for Snakemake.
 The `--cluster-status` option is used to tell Snakemake which script to use.
 
-Create the following `status.py` file
+Create an executable `status.py` file
+
+```bash
+# create an empty file
+touch status.py
+
+# make it executable
+chmod +x status.py
+```
+
+and copy the following content in it
 
 ```
 #!/usr/bin/env python
@@ -415,13 +425,7 @@ else:
     print("failed")
 ```
 
-make it executable
-
-```bash
-chmod +x status.py
-```
-
-and modify the profile `slurm/config.yaml` file
+Then modify the profile `slurm/config.yaml` file
 
 ```diff
 jobs: 20


### PR DESCRIPTION
A couple of final small changes, not crucial for the workshop

- section 03
  - missing renaming of `my_rule` into `fastqc` for the first workflow
  - simpler squeue command
- section 04
  - more explicit instructions to create status.py
  - remove `--cores 2` when using slurm profile (not needed for jobs)
  - remove envs from file structure view (when creating config file) and add files related to slurm profile and logs
